### PR TITLE
Restore original action during export

### DIFF
--- a/src/babylon_js/armature.py
+++ b/src/babylon_js/armature.py
@@ -92,6 +92,8 @@ class Skeleton:
         for bone in self.bones:
             bone.assignParentIndex(self.bones)
 
+        original_action = bpySkeleton.animation_data.action
+
         if (bpySkeleton.animation_data):
             self.ranges = []
             frameOffset = 0
@@ -114,6 +116,7 @@ class Skeleton:
 
                 frameOffset = animationRange.frame_end
 
+        bpySkeleton.animation_data.action = original_action
         # mode_set's only work when there is an active object, switch bones to edit mode to rest position
         context.view_layer.objects.active = bpySkeleton
         bpy.ops.object.mode_set(mode='EDIT')


### PR DESCRIPTION
Whenever I export an armature with actions, the last action automatically gets pushed to the top of the NLA stack. For example:

![image](https://user-images.githubusercontent.com/8994/86177874-31d78200-badc-11ea-8547-b23ae6014aa1.png)

Becomes this after export:

![image](https://user-images.githubusercontent.com/8994/86177996-6b0ff200-badc-11ea-993a-dafe975e01a2.png)

Where walk_carry was the last action processed by the plugin. This also results in distortion of the animations as they are all relative to this last action.

This PR includes a fix for the issue as I perceive it (but this might just be user error).