### PR TITLE
Guard against missing animation data

### DIFF
--- a/src/babylon_js/armature.py
+++ b/src/babylon_js/armature.py
@@ -92,9 +92,9 @@ class Skeleton:
         for bone in self.bones:
             bone.assignParentIndex(self.bones)
 
-        original_action = bpySkeleton.animation_data.action
 
         if (bpySkeleton.animation_data):
+            original_action = bpySkeleton.animation_data.action
             self.ranges = []
             frameOffset = 0
             for action in bpy.data.actions:
@@ -115,8 +115,9 @@ class Skeleton:
                         bone.append_animation_pose(animationRange.frames_out[idx], firstOrLast)
 
                 frameOffset = animationRange.frame_end
-
-        bpySkeleton.animation_data.action = original_action
+                
+            bpySkeleton.animation_data.action = original_action
+            
         # mode_set's only work when there is an active object, switch bones to edit mode to rest position
         context.view_layer.objects.active = bpySkeleton
         bpy.ops.object.mode_set(mode='EDIT')


### PR DESCRIPTION
For a mesh with an armature and no animations, the export currently fails. This PR fixes this. This was my bad and introduced by my previous PR.

Not sure if related to #26 or #27 