### PR TITLE
Preserve vertex groups

### DIFF
--- a/src/babylon_js/mesh.py
+++ b/src/babylon_js/mesh.py
@@ -171,7 +171,7 @@ class Mesh(FCurveAnimatable):
         # done based on: https://docs.blender.org/api/blender2.8/bpy.types.Depsgraph.html
         depsgraph = bpy.context.evaluated_depsgraph_get()
         objectWithModifiers = bpyMesh.evaluated_get(depsgraph)
-        mesh = objectWithModifiers.to_mesh()
+        mesh = objectWithModifiers.to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)
 
         # Triangulate mesh if required
         Mesh.mesh_triangulate(mesh)


### PR DESCRIPTION
Reflecting the change described in https://developer.blender.org/T64794.

The model I was exporting had its matricesWeights array filled with zeroes. It turned out that vertex group information was lost when evaluating the mesh.