### PR TITLE
Fixed a typo in the manifest creation

### DIFF
--- a/src/babylon_js/json_exporter.py
+++ b/src/babylon_js/json_exporter.py
@@ -296,7 +296,7 @@ class JsonExporter:
             file_handler.write('{\n')
             file_handler.write('\t"version" : ' + str(calendar.timegm(time.localtime())) + ',\n')
             file_handler.write('\t"enableSceneOffline" : true,\n')
-            file_handler.write('\t"enableTextureOffline" : true\n')
+            file_handler.write('\t"enableTexturesOffline" : true\n')
             file_handler.write('}')
             file_handler.close()
 


### PR DESCRIPTION
Don't have too lengthy of an explanation here but currently the `json_exporter.py` writes `enableTextureOffline` to the manifest file, where as according to the documentation [here](https://doc.babylonjs.com/divingDeeper/scene/optimizeCached) it should be `enableTexturesOffline`.