### PR TITLE
Add ability to only export selected objects

### DIFF
--- a/src/babylon_js/__init__.py
+++ b/src/babylon_js/__init__.py
@@ -52,6 +52,11 @@ class JsonMain(bpy.types.Operator, ExportHelper):
 
     filepath: bpy.props.StringProperty(subtype = 'FILE_PATH') # assigned once the file selector returns
     filter_glob: bpy.props.StringProperty(name='.babylon',default='*.babylon', options={'HIDDEN'})
+    export_selected: bpy.props.BoolProperty(
+        name='Export only selected objects',
+        description='Export only the currently selected objects',
+        default=False
+    )
 
     def execute(self, context):
         from .json_exporter import JsonExporter
@@ -62,7 +67,8 @@ class JsonMain(bpy.types.Operator, ExportHelper):
             return {'FINISHED'}
 
         exporter = JsonExporter()
-        exporter.execute(context, self.filepath)
+        objects = bpy.context.selected_objects if self.export_selected else bpy.context.scene.objects
+        exporter.execute(context, self.filepath, objects)
 
         if (exporter.fatalError):
             self.report({'ERROR'}, exporter.fatalError)
@@ -80,6 +86,7 @@ class JsonMain(bpy.types.Operator, ExportHelper):
             text='Find export settings in the properties panels',
             icon='INFO'
         )
+        self.layout.prop(self, 'export_selected')
 #===============================================================================
 # The list of classes which sub-class a Blender class, which needs to be registered
 from . import camera

--- a/src/babylon_js/json_exporter.py
+++ b/src/babylon_js/json_exporter.py
@@ -21,7 +21,7 @@ import calendar
 class JsonExporter:
     nameSpace   = None  # assigned in execute
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    def execute(self, context, filepath):
+    def execute(self, context, filepath, objects):
         scene = context.scene
         self.scene = scene # reference for passing
         self.settings = scene.world
@@ -90,7 +90,7 @@ class JsonExporter:
                 self.sounds.append(Sound(self.settings.attachedSound, self.settings.autoPlaySound, self.settings.loopSound))
 
             # separate loop doing all skeletons, so available in Mesh to make skipping IK bones possible
-            for object in scene.objects:
+            for object in objects:
                 if shouldBeCulled(object): continue
 
                 scene.frame_set(currentFrame)
@@ -102,7 +102,7 @@ class JsonExporter:
                         Logger.warn('The following armature not visible in scene thus ignored: ' + object.name)
 
             # exclude light in this pass, so ShadowGenerator constructor can be passed meshesAnNodes
-            for object in scene.objects:
+            for object in objects:
                 if shouldBeCulled(object): continue
 
                 scene.frame_set(currentFrame)
@@ -144,7 +144,7 @@ class JsonExporter:
                     Logger.warn('The following object (type - ' +  object.type + ') is not currently exportable thus ignored: ' + object.name)
 
             # Lamp / shadow Generator pass; meshesAnNodes complete & forceParents included
-            for object in scene.objects:
+            for object in objects:
                 if shouldBeCulled(object): continue
 
                 if object.type == 'LIGHT':


### PR DESCRIPTION
This is useful for us to have a scene with multiple assets we'd like saved as individual files. Adds a simple option to the export dialog:

![image](https://user-images.githubusercontent.com/8994/129405196-7137f7db-2d9d-423c-ba2f-0b2c425dd744.png)

When selected, only the current selection is used in the export.