### PR TITLE
ShadowGenerator errors on nodes without castShadow attribute

### DIFF
--- a/src/babylon_js/light_shadow.py
+++ b/src/babylon_js/light_shadow.py
@@ -172,7 +172,7 @@ class ShadowGenerator:
         # .babylon specific section
         self.shadowCasters = []
         for mesh in meshesAndNodes:
-            if (mesh.castShadows):
+            if (hasattr(mesh, 'castShadows') and mesh.castShadows):
                 self.shadowCasters.append(mesh.name)
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     def to_json_file(self, file_handler):


### PR DESCRIPTION
exporter won't export scenes with nodes of type Empty and Shadows enabled

![image](https://user-images.githubusercontent.com/512051/145711023-b38b1281-5d1c-461f-a1f7-93cb3869a651.png)
