### PR TITLE
Do not add a stray comma to the JSON

### DIFF
--- a/src/babylon_js/mesh.py
+++ b/src/babylon_js/mesh.py
@@ -610,6 +610,9 @@ class Mesh(FCurveAnimatable):
             if type(v) == str: write_string(file_handler, k, v, noComma)
             elif type(v) == float: write_float(file_handler, k, v, FLOAT_PRECISION_DEFAULT, noComma)
             elif type(v) == int: write_int(file_handler, k, v, noComma)
+            else:
+              Logger.warn('Non-scalar custom prop "' + k + '" ignored.', 2)
+              continue
             noComma = False
         file_handler.write('}')
 

--- a/src/babylon_js/node.py
+++ b/src/babylon_js/node.py
@@ -54,5 +54,8 @@ class Node(FCurveAnimatable):
             if type(v) == str: write_string(file_handler, k, v, noComma)
             elif type(v) == float: write_float(file_handler, k, v, noComma)
             elif type(v) == int: write_int(file_handler, k, v, noComma)
+            else:
+              Logger.warn('Non-scalar custom prop "' + k + '" ignored.', 2)
+              continue
             noComma = False
         file_handler.write('}')


### PR DESCRIPTION
 for meshes and nodes if custom property not one of the types that can be handled.

This makes the exporter issue a warning instead of adding a comma. It fixes the minimum example I provided in https://github.com/BabylonJS/BlenderExporter/issues/67 and all my other instances of this issue.

Because the only way to get the extraneous comma was to use something the exporter does not know how to export anyway, this fix should be safe.

Closes #67 